### PR TITLE
Fixes bug where multipart data is pasted, file not detected

### DIFF
--- a/src/trix/controllers/level_2_input_controller.coffee
+++ b/src/trix/controllers/level_2_input_controller.coffee
@@ -419,7 +419,7 @@ class Trix.Level2InputController extends Trix.InputController
     if clipboard = event.clipboardData
       "Files" in clipboard.types and
         clipboard.types.length <= 2 and
-        clipboard.files.length == 1
+        clipboard.files.length >= 1
 
   pasteEventHasPlainTextOnly = (event) ->
     if clipboard = event.clipboardData

--- a/src/trix/controllers/level_2_input_controller.coffee
+++ b/src/trix/controllers/level_2_input_controller.coffee
@@ -39,7 +39,7 @@ class Trix.Level2InputController extends Trix.InputController
     # Safe to remove each condition once fixed upstream.
     paste: (event) ->
       # https://bugs.webkit.org/show_bug.cgi?id=194921
-      if pasteEventHasFilesOnly(event)
+      if pasteEventHasAtLeastOneFile(event)
         event.preventDefault()
         @attachFiles(event.clipboardData.files)
 
@@ -415,10 +415,9 @@ class Trix.Level2InputController extends Trix.InputController
   dragEventHasFiles = (event) ->
     "Files" in (event.dataTransfer?.types ? [])
 
-  pasteEventHasFilesOnly = (event) ->
+  pasteEventHasAtLeastOneFile = (event) ->
     if clipboard = event.clipboardData
       "Files" in clipboard.types and
-        clipboard.types.length is 1 and
         clipboard.files.length >= 1
 
   pasteEventHasPlainTextOnly = (event) ->

--- a/src/trix/controllers/level_2_input_controller.coffee
+++ b/src/trix/controllers/level_2_input_controller.coffee
@@ -39,7 +39,7 @@ class Trix.Level2InputController extends Trix.InputController
     # Safe to remove each condition once fixed upstream.
     paste: (event) ->
       # https://bugs.webkit.org/show_bug.cgi?id=194921
-      if pasteEventHasAtLeastOneFile(event)
+      if pasteEventHasAFile(event)
         event.preventDefault()
         @attachFiles(event.clipboardData.files)
 
@@ -415,10 +415,11 @@ class Trix.Level2InputController extends Trix.InputController
   dragEventHasFiles = (event) ->
     "Files" in (event.dataTransfer?.types ? [])
 
-  pasteEventHasAtLeastOneFile = (event) ->
+  pasteEventHasAFile = (event) ->
     if clipboard = event.clipboardData
       "Files" in clipboard.types and
-        clipboard.files.length >= 1
+        clipboard.types.length <= 2 and
+        clipboard.files.length == 1
 
   pasteEventHasPlainTextOnly = (event) ->
     if clipboard = event.clipboardData

--- a/test/src/system/level_2_input_test.coffee
+++ b/test/src/system/level_2_input_test.coffee
@@ -171,6 +171,19 @@ testGroup "Level 2 Input", testOptions, ->
         assert.textAttributes([0, url.length], href: url)
         expectDocument "#{url}\n"
 
+  # Pastes from Google Chrome include text/html + a file, we want the file!
+  # https://input-inspector.javan.us/profiles/r1s8c7DqbOQXXjz76mj0
+  test "pasting image copied from Google Chrome", (expectDocument) ->
+    createFile (file) ->
+      clipboardData = dataTransfer = createDataTransfer
+        "text/html": """<meta charset='utf-8'><img src="https://www.google.com/images/branding/googlelogo/2x/googlelogo_light_color_272x92dp.png" alt="Google"/>"""
+        "Files": [file]
+
+      paste {dataTransfer}, ->
+        attachments = getDocument().getAttachments()
+        assert.equal attachments.length, 1
+        expectDocument ""
+
   # Pastes from MS Word include an image of the copied text 🙃
   # https://input-inspector.now.sh/profiles/QWDITsV60dpEVl1SOZg8
   test "pasting text from MS Word", (expectDocument) ->
@@ -183,7 +196,7 @@ testGroup "Level 2 Input", testOptions, ->
       paste {dataTransfer}, ->
         attachments = getDocument().getAttachments()
         assert.equal attachments.length, 0
-        expectDocument "abc\n"
+        expectDocument "abc\n" 
 
   # "beforeinput" event is not fired for Paste and Match Style operations
   # - https://bugs.chromium.org/p/chromium/issues/detail?id=934448


### PR DESCRIPTION
### The Bug

Assume two users, A and B, are collaborating.

User A uses their Google Chrome browser to copy an image (right clicks on an image > Copy Image) and pastes it into Trix. The source of the image is a private application that only A has access to (i.e. the image path is protected by authentication).

User A can see their image is successfully rendered in Trix, and happily saves their changes.

User B logs in to contribute to the content. They fire up Trix. 

The image pasted by User A cannot be displayed (since User B does not have access to the path).

### Why is this a bug?

When User A pasted into Trix, the clipboard data contains both the image URL/markup + actual file. 

See https://input-inspector.javan.us/profiles/r1s8c7DqbOQXXjz76mj0 for an example.

So, there are two items in the clipboard, however, Trix doesn't treat the paste as a file, but rather markup. This is because of existing code that tries to work around a Microsoft Office quirk, that includes an image of the copied text when content is copied from Word etc. 

### The Proposed Fix

Without inspecting the content to deal with the MS Word issue (we could search for `MsoNormal`), we simply invoke the existing logic if there are 3 (or more) types, i.e. `text/html`, `text/plain` and a file. If there are only two types, i.e. `text/html` and file, we should be good (hopefully!).


